### PR TITLE
Update classic infra API Key

### DIFF
--- a/iam-classic_infra_keys.md
+++ b/iam-classic_infra_keys.md
@@ -42,7 +42,9 @@ When you create a classic infrastructure API key, you can use the IP address res
 
 To get the details of a classic infrastructure API key after you create it, click the **View details** option from the **Actions** ![List of actions icon](../icons/action-menu-icon.svg) menu. You can copy the API key value.
 
-To get the details including the user name of a classic infrastructure API key after you create it, go to **Manage** > **Access (IAM)** > **Users**, then select the user's name. From the API keys section, select **View details** from the **Actions** ![List of actions icon](../icons/action-menu-icon.svg) menu in the row for the classic infrastructure API key row. You can copy the API key value or get your API user name, which is also called your classic infrastructure user name.
+To get the details of a classic infrastructure API key after you create it, go to **Manage** > **Access (IAM)** > **Users**, then select the user's name. From the API keys section, select **View details** from the **Actions** ![List of actions icon](../icons/action-menu-icon.svg) menu in the row for the classic infrastructure API key row. You can copy the API key value.
+
+In most cases, the username of your classic infrastructure API key will be your `<account_ID>_<email_address>`
 {: tip}
      
 To delete a classic infrastructure API key, select **Delete** from the **Actions** ![List of actions icon](../icons/action-menu-icon.svg) menu on the row for the API key in the API keys section.

--- a/iam-classic_infra_keys.md
+++ b/iam-classic_infra_keys.md
@@ -3,7 +3,7 @@
 copyright:
 
   years: 2018, 2020
-lastupdated: "2020-06-15"
+lastupdated: "2020-08-19"
 
 keywords: classic infrastructure API keys, classic infrastructure API, SoftLayer API key
 
@@ -44,7 +44,7 @@ To get the details of a classic infrastructure API key after you create it, clic
 
 To get the details of a classic infrastructure API key after you create it, go to **Manage** > **Access (IAM)** > **Users**, then select the user's name. From the API keys section, select **View details** from the **Actions** ![List of actions icon](../icons/action-menu-icon.svg) menu in the row for the classic infrastructure API key row. You can copy the API key value.
 
-In most cases, the username of your classic infrastructure API key will be your `<account_ID>_<email_address>`
+In most cases, the username of your classic infrastructure API key will be your `<account_ID>_<email_address>`. It is the same as your VPN username displayed on your User details page in the VPN password section.
 {: tip}
      
 To delete a classic infrastructure API key, select **Delete** from the **Actions** ![List of actions icon](../icons/action-menu-icon.svg) menu on the row for the API key in the API keys section.


### PR DESCRIPTION

<img width="965" alt="ibm_api_key" src="https://user-images.githubusercontent.com/5605413/90677907-dfc8f800-e212-11ea-99cf-1e4a288f800b.png">
In the console, if you select your classic infra API key, there is not an option for username, only description, email address, date created, created by, and the API Key Value. In my case, my classic infra username is the same as my "VPN" username shown in the IAM overview for my user, but I doubt this is standard, my username is not the same as my email. 