### PR TITLE
Update resourcegroups.md

### DIFF
--- a/resourcegroups.md
+++ b/resourcegroups.md
@@ -51,7 +51,7 @@ Connections between a resource group and a Cloud Foundry org or space are restri
 1. In the console, go to **Manage** > **Account** > **Account resources** > **Resource groups**.
 2. Click **Create**.
 3. Enter a name for your resource group. 
-4. Click **Add**.
+4. Click **Create**.
 
 ### Creating a resource group by using the CLI
 {: #rgs_cli}


### PR DESCRIPTION
Reviewing the procedure this morning - under the steps for creating a resource group in the console we use the word "Create" and not "Add" on the button for creating a resource group.