### PR TITLE
New policy limits by tags information

### DIFF
--- a/iam-policy-number.md
+++ b/iam-policy-number.md
@@ -104,7 +104,7 @@ If you meet all of the listed criteria, you can request a policy limit increase 
 * Account ID
 * Note how many extra policies in the account are required
 * If you are requesting an increase per subject, note how many extra policies per subject are required
-* If you are requesting an increase of policies with tags, note how many extra policies with tags are required
+* If you are requesting an increase of policies with access management tags, note how many extra policies with tags are required
 * An estimate of when you expect or plan to create extra policies
 
 You are notified of the update to your policy limits through the case.

--- a/iam-policy-number.md
+++ b/iam-policy-number.md
@@ -104,7 +104,7 @@ If you meet all of the listed criteria, you can request a policy limit increase 
 * Account ID
 * Note how many extra policies in the account are required
 * If you are requesting an increase per subject, note how many extra policies per subject are required
-* If you are requesting an increase of policies with access management tags, note how many extra policies with tags are required
+* If you are requesting an increase of policies with access management tags, note how many extra policies with access management tags are required
 * An estimate of when you expect or plan to create extra policies
 
 You are notified of the update to your policy limits through the case.

--- a/iam-policy-number.md
+++ b/iam-policy-number.md
@@ -104,6 +104,7 @@ If you meet all of the listed criteria, you can request a policy limit increase 
 * Account ID
 * Note how many extra policies in the account are required
 * If you are requesting an increase per subject, note how many extra policies per subject are required
+* If you are requesting an increase of policies with tags, note how many extra policies with tags are required
 * An estimate of when you expect or plan to create extra policies
 
 You are notified of the update to your policy limits through the case.

--- a/known-issues.md
+++ b/known-issues.md
@@ -73,6 +73,7 @@ The following table lists the maximum limits for IAM resources. These limits app
 | Dynamic rules per access group         | 5    |
 | Policies per account                   | 2010 |
 | Policies per subject within an account | 500  |
+| Policies with tags within an account   | 25   |
 | Service IDs per account                | 2000 |
 {:caption="Table 1. IAM account limits" caption-side="top"}
 

--- a/known-issues.md
+++ b/known-issues.md
@@ -62,19 +62,19 @@ Turning off {{site.data.keyword.cloud_notm}} catalog visibility or excluding all
 The following table lists the maximum limits for IAM resources. These limits apply to any user who can create IAM resources. If a limit is exceeded, you receive an exception and are not allowed to create any new resources beyond that limit.
 {:shortdesc}
 
-| Resource                               | Max  |
-|----------------------------------------|------|
-| Access groups per account              | 500  |
-| Access groups per user                 | 50   |
-| Access management tags per account     | 30   |
-| API Keys per identity                  | 20   |
-| Cloud Foundry orgs                     | 500  |
-| Custom roles per account               | 40   |
-| Dynamic rules per access group         | 5    |
-| Policies per account                   | 2010 |
-| Policies per subject within an account | 500  |
-| Policies with tags within an account   | 25   |
-| Service IDs per account                | 2000 |
+| Resource                                                 | Max  |
+|----------------------------------------------------------|------|
+| Access groups per account                                | 500  |
+| Access groups per user                                   | 50   |
+| Access management tags per account                       | 30   |
+| API Keys per identity                                    | 20   |
+| Cloud Foundry orgs                                       | 500  |
+| Custom roles per account                                 | 40   |
+| Dynamic rules per access group                           | 5    |
+| Policies per account                                     | 2010 |
+| Policies per subject within an account                   | 500  |
+| Policies with access management tags within an account   | 25   |
+| Service IDs per account                                  | 2000 |
 {:caption="Table 1. IAM account limits" caption-side="top"}
 
 A maximum of 1,000 policies and service to service authorizations within one account is recommended to ensure optimal performance within your account. For more information about limiting the number of policies in your account, see the [Best practices for organizing resources and assigning access](/docs/account?topic=account-account_setup).


### PR DESCRIPTION
The changes are for a new addition to policy limits by the IAM team. An additional default limit has been made of 25 policies that contain/are using tags.

We will merge this closer to deployment to production, which will be early the week of July 12th, 2020. Thus, I have set it to a draft PR. Closer to date I will change to ready for review.