### PR TITLE
Update iam-serviceid_keys.md

### DIFF
--- a/iam-serviceid_keys.md
+++ b/iam-serviceid_keys.md
@@ -63,7 +63,7 @@ ibmcloud iam service-api-key-create NAME (SERVICE_ID_NAME|SERVICE_ID_UUID) [-d, 
 ```
 {: codeblock}
 
-## Updating an API key for a service ID by using the cosole
+## Updating an API key for a service ID by using the console
 {: #update_service_key}
 {: ui}
 


### PR DESCRIPTION
fix typo `console` was spelled incorrectly as `cosole`